### PR TITLE
Problem solved during imports flattening 

### DIFF
--- a/code/core/asmeta.parser/asmeta.parser/src/org/asmeta/parser/util/ImportFlattener.java
+++ b/code/core/asmeta.parser/asmeta.parser/src/org/asmeta/parser/util/ImportFlattener.java
@@ -72,7 +72,7 @@ public class ImportFlattener {
 		Signature signature;
 		Initialization defaultInitialState;
 		Set<Asm> asmSet = new HashSet<Asm>();
-		getAsms(list, asmSet);
+		getAsms(list, asmSet, this.folder);
 		for (Asm asm : asmSet) {
 			signature = asm.getHeaderSection().getSignature();
 			domains.addAll(signature.getDomain());
@@ -91,9 +91,10 @@ public class ImportFlattener {
 	 * 
 	 * @param list   the list of imported clauses
 	 * @param asmSet the set of imported ASMs
+	 * @param folder the current parent folder of the visiting file or library
 	 * 
 	 */
-	private void getAsms(List<ImportClause> list, Set<Asm> asmSet) {
+	private void getAsms(List<ImportClause> list, Set<Asm> asmSet, String folder) {
 		String moduleName;// name of the imported module
 		File file;
 		AsmCollection asms;
@@ -114,7 +115,7 @@ public class ImportFlattener {
 					}
 					main = asms.getMain();
 					asmSet.add(main);
-					getAsms(main.getHeaderSection().getImportClause(), asmSet);
+					getAsms(main.getHeaderSection().getImportClause(), asmSet, file.getParent());
 				}
 			}
 		}


### PR DESCRIPTION
During the imports flattening process, the folder attribute doesn't change, which causes an error when other libraries are imported beyond Standard Library and CTL library.
Use Case: 
If I create a model and two other libraries (and place them in a different folder), then I make the model imports one of the two libraries and this last one imports the remaining library. The last one won't be recognised because the method will look for it in the model folder.